### PR TITLE
Use the misc feature of vcs_info to show more information in the prompt

### DIFF
--- a/20_Prompt.zsh
+++ b/20_Prompt.zsh
@@ -14,6 +14,29 @@ zstyle ':vcs_info:*' unstagedstr ':U'
 zstyle ':vcs_info:(hg|git):*' actionformats '%F{5}(%f%s%F{5})%F{3}-%F{5}[%F{2}%b%F{3}%c%u%m|%F{1}%a%F{5}]%f '
 zstyle ':vcs_info:(hg|git):*' formats '%F{5}(%f%s%F{5})%F{3}-%F{5}[%F{2}%b%F{5}%c%u%m]%f '
 
+zstyle ':vcs_info:git*+set-message:*' hooks git-aheadbehind git-stash
+
+# https://github.com/blaenk/dots/blob/master/zsh/zsh/vcsinfo.zsh
+function +vi-git-aheadbehind() {
+    local ahead behind
+    local -a gitstatus
+
+    behind=$(git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l | tr -d ' ')
+    (( $behind )) && gitstatus+=( "-${behind}" )
+
+    ahead=$(git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l | tr -d ' ')
+    (( $ahead )) && gitstatus+=( "+${ahead}" )
+
+    [ 0 -eq ${#gitstatus[@]} ] || hook_com[misc]+=":${(j::)gitstatus}"
+}
+
+function +vi-git-stash() {
+    if [[ -s ${hook_com[base]}/.git/refs/stash ]]
+    then
+        hook_com[misc]+=':$'
+    fi
+}
+
 # Prompt theme
 function promptSetup () {
     setopt prompt_subst


### PR DESCRIPTION
It will add the following elements to the prompt

`:$`
    If there is anything stashed

`+\d`
    If the current HEAD is mirroring an upstream branch it is \d commits ahead

`-\d`
    If the current HEAD is mirroring an upstream branch it is \d commits behind

`+\d-\d`
    If the current HEAD is mirroring an upstream branch it is diverged

![2015-02-22-073945_148x42_scrot](https://cloud.githubusercontent.com/assets/694012/6317738/47a3da4c-ba66-11e4-993f-56d6d49f192c.png)

![2015-02-22-073959_144x34_scrot](https://cloud.githubusercontent.com/assets/694012/6317739/47a4439c-ba66-11e4-966f-489dd984196e.png)
