### PR TITLE
Cache coreutils path to avoid invocation of brew everytime

### DIFF
--- a/00_OS-Darwin.zsh
+++ b/00_OS-Darwin.zsh
@@ -1,6 +1,13 @@
 [[ $(uname -s) == "Darwin" ]] || return
 
-BREW_COREUTILS=$(brew --prefix coreutils)
+if which brew > /dev/null
+then
+    if [ ! -f "$ZSH/cache/coreutils_path" ]
+    then
+        brew --prefix coreutils > "$ZSH/cache/coreutils_path"
+    fi
+    BREW_COREUTILS=$(cat "$ZSH/cache/coreutils_path")
+fi
 
 if [ -d $BREW_COREUTILS ]; then
     # let GNU coreutils installed by brew take preecedence on Mac systems


### PR DESCRIPTION
 Cache coreutils path to avoid invocation of brew everytime when opening a shell.

brew --prefix coreutils can take between 300ms and 500ms which is noticable
when opening new terminals.
